### PR TITLE
Rsheldon/ch5194/fork jr and get rid of serializer shortcut

### DIFF
--- a/lib/jsonapi/resource_serializer.rb
+++ b/lib/jsonapi/resource_serializer.rb
@@ -455,11 +455,12 @@ module JSONAPI
     def foreign_key_value(source, relationship)
       related_resource_id = if source.preloaded_fragments.has_key?(format_key(relationship.name))
         source.preloaded_fragments[format_key(relationship.name)].values.first.try(:id)
-      elsif source.respond_to?("#{relationship.name}_id")
-        # If you have direct access to the underlying id, you don't have to load the relationship
-        # which can save quite a lot of time when loading a lot of data.
-        # This does not apply to e.g. has_one :through relationships.
-        source.public_send("#{relationship.name}_id")
+      # NOTE(Rsheldon) removing this as it messes up to-one relationships with hashed_ids
+      # elsif source.respond_to?("#{relationship.name}_id")
+      #   # If you have direct access to the underlying id, you don't have to load the relationship
+      #   # which can save quite a lot of time when loading a lot of data.
+      #   # This does not apply to e.g. has_one :through relationships.
+      #   source.public_send("#{relationship.name}_id")
       else
         source.public_send(relationship.name).try(:id)
       end


### PR DESCRIPTION
we're doing some funky business in JR with nonprimary keys being the identifier for resources. JR didn't really plan for this in the past, and assumed that underlying DB keys would be the keys of the resources. We've gotten by with monkey patches for the most part now, and this could also be a monkey patch if we wanted, but so far we've monkey patched extension classes and not underlying classes. I figured it'd be better to have this in a fork, since the function no longer exists on master of JR, and if we were to upgrade without a fork we may lose this functionality.